### PR TITLE
(BSR) make rendered manifests push to branch named after application

### DIFF
--- a/actions/render-push-manifests/action.yml
+++ b/actions/render-push-manifests/action.yml
@@ -84,5 +84,5 @@ runs:
         destination-github-username: 'pass-culture'
         destination-repository-name: 'rendered-manifests'
         commit-message: "${{ inputs.app_name }}(${{ inputs.environment }}) : pushed rendered manifests for app_version=${{ inputs.app_version }}"
-        target-branch: ${{ inputs.environment }}
+        target-branch: "${{ inputs.app_name }}/${{ inputs.environment }}"
         create-target-branch-if-needed: true


### PR DESCRIPTION
L'idée c'est de faire en sorte que les rendered manifests soient push sur une branche qui correspond au nom de l'application pour permettre de généraliser l'utilisation de ce pattern.

Vu qu'on versionne l'action cette PR devrait être safe à merger pour commencer à l'utiliser sur d'autres applis.