### PR TITLE
PC-29754 - Adapt render-manifest composite for helm value CI

### DIFF
--- a/actions/render-push-manifests/action.yml
+++ b/actions/render-push-manifests/action.yml
@@ -24,13 +24,24 @@ inputs:
     type: string
     required: true
   chart_values_repository:
-    description: "Repository containing helm chart values"
+    description: "Repository containing helm chart values. Optional if called from a values repository"
     type: string
-    required: true
-  chart_values_destination:
-    description: "Path where repository will be cloned. Helmfile.yaml must reference this path"
+    required: false
+  chart_values_repository_ref:
+    description: "Repository ref containing helm chart values"
     type: string
-    required: true
+    required: false    
+    default: ''
+  helmfile_path:
+    description: "Location of helmfile.yaml inside repository"
+    type: string
+    required: false
+    default: "."
+  rendered_manifests_target_branch:
+    description: "Target branch for rendered-manifests. Mainly used for testing purposes, Use with caution."
+    type: string
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -52,14 +63,19 @@ runs:
         workload_identity_provider: ${{ steps.get-secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ steps.get-secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
     - uses: actions/checkout@v4.1.5
+      if: inputs.chart_values_repository == true
       with:
         repository: ${{ inputs.chart_values_repository }}
         token: ${{ steps.get-secrets.outputs.API_TOKEN_GITHUB }}
-        path: ${{ inputs.chart_values_destination }}
+        ref: ${{ inputs.chart_values_repository_ref }}
+    - name: "Setup helmfile"
+      uses: mamezou-tech/setup-helmfile@v1.3.0
+      with:
+        helmfile-version: "v0.147.0"
     - name: "Render manifests"
       shell: bash
       run: |
-        helmfile_template=(helmfile -e $ENVIRONMENT template --output-dir ./rendered-manifests/ --output-dir-template "{{ .OutputDir }}/{{ .State.BaseName }}-{{ .Release.Name  }}") 
+        helmfile_template=(helmfile -f ${{ inputs.helmfile_path }}/helmfile.yaml -e $ENVIRONMENT template --output-dir ./rendered-manifests/ --output-dir-template "{{ .OutputDir }}/{{ .State.BaseName }}-{{ .Release.Name  }}") 
         if [ "${ADDITIONAL_ARGS}" ]; then
           helmfile_template+=(--set $ADDITIONAL_ARGS)
         fi
@@ -80,9 +96,9 @@ runs:
       env:
         API_TOKEN_GITHUB: ${{ steps.get-secrets.outputs.API_TOKEN_GITHUB }}
       with:
-        source-directory: ./rendered-manifests/helmfile-${{ inputs.environment }}/
+        source-directory: ${{ inputs.helmfile_path }}/rendered-manifests/helmfile-${{ inputs.environment }}/
         destination-github-username: 'pass-culture'
         destination-repository-name: 'rendered-manifests'
-        commit-message: "${{ inputs.app_name }}(${{ inputs.environment }}) : pushed rendered manifests for app_version=${{ inputs.app_version }}"
-        target-branch: "${{ inputs.app_name }}/${{ inputs.environment }}"
+        commit-message: "${{ inputs.app_name }}(${{ inputs.environment }}) : manifests for app_version=${{ inputs.app_version }}"
+        target-branch: ${{ inputs.rendered_manifests_target_branch == '' && inputs.environment || inputs.rendered_manifests_target_branch }}
         create-target-branch-if-needed: true


### PR DESCRIPTION
render-push-manifests v1.1.0 :
Adapted render-push-manifests composite for future helm values CI :
- Optional ref for values repository. If not set, it will checkout default branch. 
- Optional target branch for rendered manifests. May be useful for developing and pushing results into rendered-manifest repository without impacting environment branches.
- Path for helmfile.yaml not always in root repository folder