### PR TITLE
PC-31824 - retry backoff settings for argocd app sync

### DIFF
--- a/actions/argocd-sync/action.yml
+++ b/actions/argocd-sync/action.yml
@@ -9,7 +9,18 @@ inputs:
     description: The timeout to wait for before aborting the sync
     required: false
     default: 600
-
+  retry_backoff_duration:
+    description: Retry backoff base duration.
+    required: false
+    default: '5s'
+  retry_backoff_factor:
+    description: Factor multiplies the base duration after each failed retry
+    required: false
+    default: 1
+  retry_backoff_max_duration:
+    description: Max retry backoff duration.
+    required: false
+    default: '1m'
 
 runs:
   using: 'composite'
@@ -27,4 +38,10 @@ runs:
       shell: bash
       run: |
         kubectl config set-context --current --namespace=argocd
-        argocd app sync ${{ inputs.app_name }} --core --apply-out-of-sync-only --timeout ${{ inputs.sync_timeout }}
+        argocd app sync ${{ inputs.app_name }} \
+          --core \
+          --apply-out-of-sync-only \
+          --retry-backoff-duration ${{ inputs.retry_backoff_duration }} \
+          --retry-backoff-factor ${{ inputs.retry_backoff_factor }} \
+          --retry-backoff-max-duration ${{ inputs.retry_backoff_max_duration }} \
+          --timeout ${{ inputs.sync_timeout }}


### PR DESCRIPTION
Added 3 settings for argocd app sync cli cmd, as inputs to allow further tweaking w/o bumping composite version : 

--retry-backoff-duration : sync retry delay (default 5s, previously was 5s)
--retry-backoff-factor : retry-backoff-duration multiplier after each unsecussfull attempt (default 1, previously was 2)
--retry-backoff-max-duration : max-retry delay (duration x factor). (default 1min, previously was 3)

