### PR TITLE
(PC-34364) bash should interprete variable

### DIFF
--- a/actions/render-push-manifests/action.yml
+++ b/actions/render-push-manifests/action.yml
@@ -119,7 +119,7 @@ runs:
         else
           output_dir_tpl="{{ .OutputDir }}"
         fi
-        helmfile_template=(helmfile -f ${{ inputs.helmfile_path }}/helmfile.yaml -e $ENVIRONMENT template --output-dir ${{ github.workspace }}/rendered-manifests/ --output-dir-template $output_dir_tpl)
+        helmfile_template=(helmfile -f ${{ inputs.helmfile_path }}/helmfile.yaml -e $ENVIRONMENT template --output-dir ${{ github.workspace }}/rendered-manifests/ --output-dir-template "${output_dir_tpl}")
         if [ "${ADDITIONAL_ARGS}" ]; then
           helmfile_template+=(--set $ADDITIONAL_ARGS)
         fi


### PR DESCRIPTION
Two be able to render a good $output_dir_tpl {{ .OutputDir }} should be enclose with "" (wasn't effective since 2.0.1) 